### PR TITLE
feat: Add serious, creative, and zany title components

### DIFF
--- a/TitleCreator.py
+++ b/TitleCreator.py
@@ -1,32 +1,52 @@
 #!/usr/bin/env python3
 # We're now approaching enterprise grade.
+# This script generates random job titles. The lists of title components
+# have been expanded to include a mix of serious, creative, and zany options
+# to enhance the variety and fun of the generated titles.
 from random import seed, choice
 
 seed()
 
 def ofprefix():
+    # List of prefixes for titles using 'of' (e.g., Viceroy of Engineering)
+    # Expanded for more variety (serious, creative, zany).
     l = ['Viceroy', 'Commandant', 'Grand Poo-Bah', 'Archon', 'Duke', 'Chancellor', 'President', 'Marquis',
             'Earl', 'Director', 'Chair', 'Head', 'Senior Director', 'Vice President', 'Dark Lord',
-            'Dread Lord', 'Czar', 'Emperor', 'Baron', 'Guru']
+            'Dread Lord', 'Czar', 'Emperor', 'Baron', 'Guru', 'Supreme Commander', 'Galactic Overlord',
+            'Chief Visionary Officer', 'Master of Coin', 'Head Honcho', 'The Big Cheese', 'Captain']
     return choice(l)
 
 def prefix():
-    l = ['Principal', 'Master Chief', 'Chief', 'Head', 'Lead', 'Senior', 'Master', 'Premier', 'Scrum Certified']
+    # List of general prefixes (e.g., Principal Solutions Architect)
+    # Expanded for more variety (serious, creative, zany).
+    l = ['Principal', 'Master Chief', 'Chief', 'Head', 'Lead', 'Senior', 'Master', 'Premier', 'Scrum Certified',
+            'Distinguished', 'Elite', 'Galactic', 'Cyber', 'Quantum', 'Supreme', 'Ninja']
     return choice(l)
 
 def job():
+    # List of job areas or focuses (e.g., Cloud, DevOps)
+    # Expanded for more variety (serious, creative, zany).
     l = ['Solutions', 'Systems', 'Network', 'Security', 'Compliance', 'Information', 'Scalability',
-            'Database', 'Platform', 'Storage', 'Cloud', 'DevOps', 'Blockchain', 'Serverless', 'Reliability']
+            'Database', 'Platform', 'Storage', 'Cloud', 'DevOps', 'Blockchain', 'Serverless', 'Reliability',
+            'Innovation', 'Synergy', 'Cybersecurity', 'Digital Transformation', 'Meme Curation',
+            'Cat Herding', 'Quantum Entanglement']
     return choice(l)
 
 def ofpostfix():
+    # List of postfixes for titles using 'of' (e.g., Viceroy of Engineering)
+    # Expanded for more variety (serious, creative, zany).
     l = ['Engineering',
             'Management', 'Development', 'Deployment', 'Technical Training', 'Operations', 'Architecture',
-            'Infrastructure', 'Technology', 'Administration', 'Thought Leadership', 'Shiny Things', 'Agility']
+            'Infrastructure', 'Technology', 'Administration', 'Thought Leadership', 'Shiny Things', 'Agility',
+            'Strategy', 'Global Dominance', 'Creative Solutions', 'Advanced Shenanigans', 'Future Planning',
+            'Resource Allocation', 'Mischief Management']
     return choice(l)
 
 def postfix():
-    l = ['Engineer', 'Architect', 'Designer', 'Consultant', 'Manager', 'Officer', 'Leader', 'Janitor', 'Plumber']
+    # List of general postfixes (e.g., Principal Solutions Architect)
+    # Expanded for more variety (serious, creative, zany).
+    l = ['Engineer', 'Architect', 'Designer', 'Consultant', 'Manager', 'Officer', 'Leader', 'Janitor', 'Plumber',
+            'Specialist', 'Evangelist', 'Wizard', 'Ninja Rockstar', 'Overlord', 'Sensei', 'Visionary']
     return choice(l)
 
 def ofornot():

--- a/test_titlecreator.py
+++ b/test_titlecreator.py
@@ -1,0 +1,56 @@
+import subprocess
+import unittest
+
+class TestTitleCreator(unittest.TestCase):
+
+    def test_title_generator_smoke(self):
+        """
+        Smoke test for TitleCreator.py.
+        Runs the script multiple times and checks basic output structure.
+        """
+        for i in range(20):
+            # Execute TitleCreator.py as a subprocess
+            # Ensure using python3, as the script has a shebang for python3
+            process = subprocess.run(
+                ['python3', 'TitleCreator.py'],
+                capture_output=True,
+                text=True,  # Decodes stdout and stderr as UTF-8
+                check=True  # Raises CalledProcessError if return code is non-zero
+            )
+
+            output = process.stdout
+
+            # 1. Assert that the script produces an output
+            self.assertTrue(output, msg=f"Run {i+1}: Output was empty")
+
+            # 2. Assert that the output contains the introductory line
+            self.assertIn(
+                "Congratulations! Your new title is:",
+                output,
+                msg=f"Run {i+1}: Introductory line not found in output:\n{output}"
+            )
+
+            lines = output.strip().split('\n')
+
+            # 3. Assert that there are at least two lines (intro + title)
+            self.assertGreaterEqual(
+                len(lines),
+                2,
+                msg=f"Run {i+1}: Expected at least 2 lines, got {len(lines)} in output:\n{output}"
+            )
+
+            # 4. Assert that the actual generated title string is not empty
+            generated_title = lines[1]
+            self.assertTrue(
+                generated_title,
+                msg=f"Run {i+1}: Generated title string is empty in output:\n{output}"
+            )
+            # 5. (Implicit) Assert title is a string - already true due to text=True and split
+            self.assertIsInstance(
+                generated_title,
+                str,
+                msg=f"Run {i+1}: Generated title is not a string in output:\n{output}"
+            )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Expands the lists of prefixes, job roles, and postfixes in TitleCreator.py to include a wider variety of serious, creative, and zany options. This significantly increases the diversity and entertainment value of the generated titles.

The core title generation logic remains unchanged.

In-code documentation has been updated to reflect these additions. A new smoke test (`test_titlecreator.py`) has also been added to ensure the script runs correctly and produces valid output.