### PR TITLE
Add Dockerfile for TitleCreator application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Git files
+.git/
+.gitignore
+
+# Potentially outdated App Engine config
+app.yaml
+
+# Dockerfile itself
+Dockerfile
+
+# Test files (if not needed in the final image)
+test_titlecreator.py
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official Python 3 slim base image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the Python script into the container
+COPY TitleCreator.py .
+
+# Make the script executable (though it's run with python interpreter)
+# RUN chmod +x TitleCreator.py
+
+# Set the command to run when the container starts
+CMD ["python", "./TitleCreator.py"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Enter this in the command line:
 
 ^ You did it! You have a new title! Add it to your Linkedin.
 
+## Instructions to run with Docker:
+
+1.  **Build the Docker image:**
+    Open your terminal in the root directory of this project (where the `Dockerfile` is located) and run:
+    ```bash
+    docker build -t titlecreator .
+    ```
+
+2.  **Run the Docker container:**
+    After the image is built successfully, you can get a new title by running:
+    ```bash
+    docker run --rm titlecreator
+    ```
+    The `--rm` flag automatically removes the container when it exits.
+
 #### COMING SOON
 
 a `golang` version 


### PR DESCRIPTION
This commit introduces a Dockerfile to containerize the TitleCreator Python script.

Key changes:
- Added `Dockerfile` using a python:3.9-slim base image, which copies `TitleCreator.py` and sets it as the CMD.
- Added `.dockerignore` to exclude unnecessary files (.git, app.yaml, etc.) from the Docker build context.
- Updated `README.md` with instructions on how to build and run the application using Docker.

The `app.yaml` file was excluded as it appeared to be outdated (referencing python27 and a different script name) and not directly relevant to running the current `TitleCreator.py` script in a Docker container.