### PR TITLE
feat: Add GitHub Action to publish Docker image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Git files
+.git/
+.gitignore
+
+# Potentially outdated App Engine config
+app.yaml
+
+# Dockerfile itself
+Dockerfile
+
+# Test files (if not needed in the final image)
+test_titlecreator.py
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    branches:
+      - main  # Or master, or your default branch
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Required to publish packages to GHCR
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }} # ghcr.io/OWNER/REPO
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official Python 3 slim base image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the Python script into the container
+COPY TitleCreator.py .
+
+# Make the script executable (though it's run with python interpreter)
+# RUN chmod +x TitleCreator.py
+
+# Set the command to run when the container starts
+CMD ["python", "./TitleCreator.py"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,40 @@ Enter this in the command line:
 
 ^ You did it! You have a new title! Add it to your Linkedin.
 
+## Instructions to run with Docker:
+
+1.  **Build the Docker image:**
+    Open your terminal in the root directory of this project (where the `Dockerfile` is located) and run:
+    ```bash
+    docker build -t titlecreator .
+    ```
+
+2.  **Run the Docker container:**
+    After the image is built successfully, you can get a new title by running:
+    ```bash
+    docker run --rm titlecreator
+    ```
+    The `--rm` flag automatically removes the container when it exits.
+
+## Using the Public Docker Image (from GHCR)
+
+This repository automatically builds and publishes a Docker image to the GitHub Container Registry (GHCR) whenever changes are pushed to the `main` branch.
+
+You can pull and run this pre-built image directly:
+
+1.  **Pull the latest image:**
+    ```bash
+    docker pull ghcr.io/YOUR_GITHUB_USERNAME/YOUR_REPOSITORY_NAME:latest
+    ```
+    *(You'll need to replace `YOUR_GITHUB_USERNAME/YOUR_REPOSITORY_NAME` with the actual path to this repository, e.g., `gabinante/TitleCreator` if that's the correct path)*
+
+2.  **Run the container:**
+    ```bash
+    docker run --rm ghcr.io/YOUR_GITHUB_USERNAME/YOUR_REPOSITORY_NAME:latest
+    ```
+
+    This will output a new title, just like running it locally or building it yourself.
+
 #### COMING SOON
 
 a `golang` version 


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automatically build and publish the Docker image for TitleCreator to the GitHub Container Registry (GHCR).

Key changes:
- Added `.github/workflows/publish-docker.yml`:
  - Triggers on push to the `main` branch.
  - Logs into GHCR using `secrets.GITHUB_TOKEN`.
  - Builds the Docker image using the existing `Dockerfile`.
  - Tags the image with `latest` and commit SHA.
  - Pushes the tagged image to `ghcr.io/<OWNER>/<REPO>`.

- Updated `README.md`:
  - Added a new section "Using the Public Docker Image (from GHCR)".
  - Provided instructions on how to pull and run the pre-built image from GHCR, using placeholders for your repository owner and name.