### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ curl -H "Accept: application/json" http://localhost:8080/
 4. **Deploy to Cloud Run:**
    ```bash
    gcloud run deploy titlecreator \
-     --image ghcr.io/sntxrr/TitleCreator:latest \
+     --image ghcr.io/sntxrr/titlecreator:latest \
      --platform managed \
      --region us-central1 \
      --allow-unauthenticated \
@@ -140,13 +140,13 @@ You can pull and run this pre-built image directly:
 
 1.  **Pull the latest image:**
     ```bash
-    docker pull ghcr.io/sntxrr/TitleCreator:latest
+    docker pull ghcr.io/sntxrr/titlecreator:latest
     ```
 
 
 2.  **Run the container:**
     ```bash
-    docker run --rm ghcr.io/sntxrr/TitleCreator:latest
+    docker run --rm ghcr.io/sntxrr/titlecreator:latest
     ```
 
     This will output a new title, just like running it locally or building it yourself.


### PR DESCRIPTION
This pull request updates the `README.md` file to fix inconsistencies in the casing of the Docker image name. The changes ensure the image name uses lowercase consistently, aligning with Docker's naming conventions.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R114): Updated the Docker image name from `TitleCreator` to `titlecreator` in the Cloud Run deployment command.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R149): Updated the Docker image name from `TitleCreator` to `titlecreator` in the `docker pull` and `docker run` commands.