### PR TITLE
fix up sha pin

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -56,13 +56,15 @@ jobs:
         run: |
           # Get the SHA of the image we just pushed
           IMAGE_SHA=$(docker inspect us-west2-docker.pkg.dev/title-gen/titlegenerator/titlecreator:latest --format='{{.RepoDigests}}' | cut -d'@' -f2)
-          echo "IMAGE_SHA=$IMAGE_SHA" >> $GITHUB_ENV
-          echo "Found image SHA: $IMAGE_SHA"
+          # Store just the SHA part without the image name
+          IMAGE_SHA_ONLY=$(echo "$IMAGE_SHA" | cut -d' ' -f1)
+          echo "IMAGE_SHA_ONLY=$IMAGE_SHA_ONLY" >> $GITHUB_ENV
+          echo "Found image SHA: $IMAGE_SHA_ONLY"
 
       - name: Update cloudrun.yaml with image SHA
         run: |
-          # Replace the IMAGE_SHA placeholder with the actual SHA
-          sed -i "s/\${IMAGE_SHA}/${{ env.IMAGE_SHA }}/" cloudrun.yaml
+          # Use perl instead of sed for better handling of special characters
+          perl -pi -e "s/\${IMAGE_SHA}/${{ env.IMAGE_SHA_ONLY }}/" cloudrun.yaml
           echo "Updated cloudrun.yaml with image SHA"
 
       - name: Deploy to Cloud Run


### PR DESCRIPTION
This pull request introduces changes to streamline the handling of Docker image SHA values and improve the reliability of the `cloudrun.yaml` update process in the GitHub Actions workflow for publishing Docker images.

Enhancements to Docker image SHA handling:

* [`.github/workflows/publish-docker.yml`](diffhunk://#diff-9136d7ee194d90376becf626f92179e6d99617d858ce125f6f73ca09fa410840L59-R67): Modified the script to extract only the SHA portion of the Docker image digest (`IMAGE_SHA_ONLY`) and store it in the GitHub environment variable, replacing the previous approach that included the full repository digest.

Improvements to `cloudrun.yaml` update process:

* [`.github/workflows/publish-docker.yml`](diffhunk://#diff-9136d7ee194d90376becf626f92179e6d99617d858ce125f6f73ca09fa410840L59-R67): Replaced `sed` with `perl` for updating the `cloudrun.yaml` file, ensuring better handling of special characters in the image SHA placeholder replacement.
[Copilot is generating a summary...]